### PR TITLE
Add error callback

### DIFF
--- a/loadJS.js
+++ b/loadJS.js
@@ -1,5 +1,5 @@
 /*! loadJS: load a JS file asynchronously. [c]2014 @scottjehl, Filament Group, Inc. (Based on http://goo.gl/REQGQ by Paul Irish). Licensed MIT */
-function loadJS( src, cb ){
+function loadJS( src, cb, errorcb ){
 	"use strict";
 	var ref = window.document.getElementsByTagName( "script" )[ 0 ];
 	var script = window.document.createElement( "script" );
@@ -8,6 +8,9 @@ function loadJS( src, cb ){
 	ref.parentNode.insertBefore( script, ref );
 	if (cb && typeof(cb) === "function") {
 		script.onload = cb;
+	}
+	if (errorcb && typeof(errorcb) === "function") {
+		script.onerror = errorcb;
 	}
 	return script;
 }


### PR DESCRIPTION
Add error callback if script fails to load (builds on #9). 

Perhaps it would be better to use one callback, or use the existing callback if an error callback is not given. Looking for feedback on this.